### PR TITLE
Reverted stripping out the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Duncan Lock
+Copyright (c) 2015 Dan Moldovan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Duncan Lock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Dan Moldovan
+Copyright (c) 2013 kelp404 <kelp@phate.org>
+Copyright (c) 2015 Dan Moldovan <danmol18@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #angular-form-builder
 
+[MIT License](http://www.opensource.org/licenses/mit-license.php)
+
 This is an AngularJS form builder written in [CoffeeScript](http://coffeescript.org) by [kelp404](http://kelp404.github.io/angular-form-builder/)
 
 ###Added multiple form support.


### PR DESCRIPTION
So, stripping the license off someone elses work is a breach of copyright. The original license explicitly forbids this: http://www.opensource.org/licenses/mit-license.php

Apart from not being very nice - and not legal - this makes using the code very problematic - the original code is under one license and your changes are copyrighted by you, maybe??

Unless you got written permission from the original copyright holder @kelp404 to make this change?

Anyway, this pull request puts the licensing back the way it should be.
