### PR TITLE
Updated demo index.html to source everything from bower_components

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>angular-form-builder</title>
-    <link type="text/css" rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
+    <link type="text/css" rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"/>
     <link type="text/css" rel="stylesheet" href="example/site.css"/>
     <link type="text/css" rel="stylesheet" href="dist/angular-form-builder.css"/>
     <link type="text/css" rel="stylesheet" href="bower_components/signature-pad/assets/jquery.signaturepad.css">
@@ -12,13 +12,13 @@
     <link type="text/css" rel="stylesheet" href="bower_components/summernote/dist/summernote.css">
     <link type="text/css" rel="stylesheet" href="bower_components/summernote/dist/summernote-bs3.css">
     <link type="text/css" rel="stylesheet" href="bower_components/iCheck/skins/square/square.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
-    <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="//code.angularjs.org/1.2.20/angular.min.js"></script>
+    <script type="text/javascript" src="bower_components/jquery/dist/jquery.min.js"></script>
+    <script type="text/javascript" src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="bower_components/angular/angular.min.js"></script>
     <script type="text/javascript" src="dist/angular-form-builder.js"></script>
     <script type="text/javascript" src="dist/angular-form-builder-components.js"></script>
-    <script type="text/javascript" src="//kelp404.github.io/angular-validator/dist/angular-validator.min.js"></script>
-    <script type="text/javascript" src="//kelp404.github.io/angular-validator/dist/angular-validator-rules.min.js"></script>
+    <script type="text/javascript" src="bower_components/angular-validator/dist/angular-validator.min.js"></script>
+    <script type="text/javascript" src="bower_components/angular-validator/dist/angular-validator-rules.min.js"></script>
     <script type="text/javascript" src="bower_components/signature-pad/jquery.signaturepad.min.js"></script>
     <script type="text/javascript" src="bower_components/signature-pad/assets/json2.min.js"></script>
     <script type="text/javascript" src="bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>


### PR DESCRIPTION
Was previously getting components from a mixture of locations - CDNs, github and the local bower_components - despite everything being available locally in bower_components. I updated it to source everything from the local bower_components folder

This is more consistent and ensures that the demo is using the correct versions of all components, rather than a mixture.

The only downside is that it won't work when run as a github.io page - but as it was already sourcing a bunch of stuff from `bower_components` - this was already broken. This was the versions are consistent with the rest of the project, making things simpler for local development.
